### PR TITLE
Feature/222 prevent delete explanation text

### DIFF
--- a/src/components/list/editListEvidenceProfile.vue
+++ b/src/components/list/editListEvidenceProfile.vue
@@ -627,22 +627,22 @@ export default {
     checkValidationText: function (type, prop) {
       switch (type) {
         case 'methodological-limitations':
-          if (prop.methodological_limitations.option > 0 && prop.methodological_limitations.explanation === '') {
+          if (parseInt(prop.methodological_limitations.option) > 0 && prop.methodological_limitations.explanation === '') {
             return true
           }
           return false
         case 'coherence':
-          if (prop.coherence.option > 0 && prop.coherence.explanation === '') {
+          if (parseInt(prop.coherence.option) > 0 && prop.coherence.explanation === '') {
             return true
           }
           return false
         case 'adequacy':
-          if (prop.adequacy.option > 0 && prop.adequacy.explanation === '') {
+          if (parseInt(prop.adequacy.option) > 0 && prop.adequacy.explanation === '') {
             return true
           }
           return false
         case 'relevance':
-          if (prop.relevance.option > 0 && prop.relevance.explanation === '') {
+          if (parseInt(prop.relevance.option) > 0 && prop.relevance.explanation === '') {
             return true
           }
           return false

--- a/src/components/list/editListEvidenceProfile.vue
+++ b/src/components/list/editListEvidenceProfile.vue
@@ -141,7 +141,7 @@
           </template>
           <p><b>{{displaySelectedOption(data.item.coherence.option)}}</b></p>
           <p v-if="data.item.coherence.explanation">
-            Explanation: {{ getExplanation('coherence', data.item.coherence.option, data.item.coherence.explanation) }}
+            <span class="font-weight-bolder text-black-50">Explanation:</span> {{ getExplanation('coherence', data.item.coherence.option, data.item.coherence.explanation) }}
             <span
               v-if="displayExclamationAlert('coherence')"
               class="text-danger"
@@ -196,7 +196,7 @@
           </template>
           <p><b>{{displaySelectedOption(data.item.adequacy.option)}}</b></p>
           <p v-if="data.item.adequacy.explanation">
-            Explanation: {{ getExplanation('adequacy', data.item.adequacy.option, data.item.adequacy.explanation) }}
+            <span class="font-weight-bolder text-black-50">Explanation:</span> {{ getExplanation('adequacy', data.item.adequacy.option, data.item.adequacy.explanation) }}
             <span
               v-if="displayExclamationAlert('adequacy')"
               class="text-danger"
@@ -251,7 +251,7 @@
           </template>
           <p><b>{{displaySelectedOption(data.item.relevance.option)}}</b></p>
           <p v-if="data.item.relevance.explanation">
-            Explanation: {{ getExplanation('relevance', data.item.relevance.option, data.item.relevance.explanation) }}
+            <span class="font-weight-bolder text-black-50">Explanation:</span> {{ getExplanation('relevance', data.item.relevance.option, data.item.relevance.explanation) }}
             <span
               v-if="displayExclamationAlert('relevance')"
               class="text-danger"
@@ -305,7 +305,9 @@
             </b-button>
           </template>
           <p><b>{{displayLevelConfidence(data.item.cerqual.option)}}</b></p>
-          <p v-if="data.item.cerqual.option && data.item.cerqual.explanation">Explanation: {{data.item.cerqual.explanation}}</p>
+          <p v-if="data.item.cerqual.option && data.item.cerqual.explanation">
+            <span class="font-weight-bolder text-black-50">Explanation:</span> {{data.item.cerqual.explanation}}
+          </p>
           <p v-else class="text-muted font-weight-light" v-b-tooltip.hover="{title: 'Provide an explanation for your assessment', placement: 'bottom'}">
             Explanation not yet added
           </p>

--- a/src/components/list/evidenceProfileForm.vue
+++ b/src/components/list/evidenceProfileForm.vue
@@ -341,7 +341,7 @@
               for practical guidance on making an overall assessment of confidence
               for a review finding.
             </p>
-            <b-form-radio-group v-model="selectedOptions.cerqual.option" name="cerqual" stacked>
+            <b-form-radio-group v-model="selectedOptions.cerqual.option" @change="generateCerqualExplanation()" name="cerqual" stacked>
               <b-form-radio value="0">
                 High confidence
                 <small v-b-tooltip.hover
@@ -905,6 +905,18 @@ export default {
     }
   },
   methods: {
+    generateCerqualExplanation: function () {
+      if (this.selectedOptions.cerqual.explanation === '') {
+        if (this.selectedOptions.methodological_limitations.option &&
+        this.selectedOptions.coherence.option &&
+        this.selectedOptions.adequacy.option &&
+        this.selectedOptions.relevance.option) {
+          this.selectedOptions.cerqual.explanation = this.displaySelectedOption(this.selectedOptions.methodological_limitations.option) + ' regarding methodological limitations, ' + this.displaySelectedOption(this.selectedOptions.coherence.option) + ' regarding coherence, ' + this.displaySelectedOption(this.selectedOptions.adequacy.option) + ' regarding adequacy, and ' + this.displaySelectedOption(this.selectedOptions.relevance.option) + ' regarding relevance'
+        } else {
+          this.selectedOptions.cerqual.explanation = ''
+        }
+      }
+    },
     getExplanation: function (type, option, explanation) {
       return displayExplanation(type, option, explanation)
     },

--- a/src/components/list/evidenceProfileForm.vue
+++ b/src/components/list/evidenceProfileForm.vue
@@ -341,7 +341,7 @@
               for practical guidance on making an overall assessment of confidence
               for a review finding.
             </p>
-            <b-form-radio-group v-model="selectedOptions.cerqual.option" @change="generateCerqualExplanation()" name="cerqual" stacked>
+            <b-form-radio-group v-model="selectedOptions.cerqual.option" @change="commonGenerateCerqualExplanation()" name="cerqual" stacked>
               <b-form-radio value="0">
                 High confidence
                 <small v-b-tooltip.hover
@@ -832,7 +832,7 @@
 
 <script>
 import axios from 'axios'
-import { displayExplanation } from '../utils/commons'
+import { displayExplanation, generateCerqualExplanation } from '../utils/commons'
 export default {
   name: 'evidenceProfileForm',
   components: {
@@ -892,30 +892,9 @@ export default {
   mounted () {
     this.selectedOptions = JSON.parse(JSON.stringify(this.modalData))
   },
-  computed: {
-    cerqualExplanation: function () {
-      if (this.selectedOptions.methodological_limitations.option &&
-        this.selectedOptions.coherence.option &&
-        this.selectedOptions.adequacy.option &&
-        this.selectedOptions.relevance.option) {
-        return this.displaySelectedOption(this.selectedOptions.methodological_limitations.option) + ' regarding methodological limitations, ' + this.displaySelectedOption(this.selectedOptions.coherence.option) + ' regarding coherence, ' + this.displaySelectedOption(this.selectedOptions.adequacy.option) + ' regarding adequacy, and ' + this.displaySelectedOption(this.selectedOptions.relevance.option) + ' regarding relevance'
-      } else {
-        return ''
-      }
-    }
-  },
   methods: {
-    generateCerqualExplanation: function () {
-      if (this.selectedOptions.cerqual.explanation === '') {
-        if (this.selectedOptions.methodological_limitations.option &&
-        this.selectedOptions.coherence.option &&
-        this.selectedOptions.adequacy.option &&
-        this.selectedOptions.relevance.option) {
-          this.selectedOptions.cerqual.explanation = this.displaySelectedOption(this.selectedOptions.methodological_limitations.option) + ' regarding methodological limitations, ' + this.displaySelectedOption(this.selectedOptions.coherence.option) + ' regarding coherence, ' + this.displaySelectedOption(this.selectedOptions.adequacy.option) + ' regarding adequacy, and ' + this.displaySelectedOption(this.selectedOptions.relevance.option) + ' regarding relevance'
-        } else {
-          this.selectedOptions.cerqual.explanation = ''
-        }
-      }
+    commonGenerateCerqualExplanation: function () {
+      this.selectedOptions.cerqual.explanation = generateCerqualExplanation(this.selectedOptions)
     },
     getExplanation: function (type, option, explanation) {
       return displayExplanation(type, option, explanation)
@@ -993,9 +972,14 @@ export default {
     },
     continueSavingDataModal: function () {
       const selectedOptions = this.selectedOptions
-      // this.evidence_profile_table_settings.isBusy = true
       this.$emit('busyEvidenceProfileTable', true)
       delete this.selectedOptions.type
+      // if (selectedOptions.cerqual.option !== null || selectedOptions.cerqual.option !== '') {
+      //   console.log('a', selectedOptions)
+      //   selectedOptions.cerqual.explanation = ''
+      //   selectedOptions.cerqual.explanation = generateCerqualExplanation(selectedOptions)
+      //   console.log('b', selectedOptions)
+      // }
       let params = {
         organization: this.list.organization,
         list_id: this.list.id,

--- a/src/components/list/evidenceProfileForm.vue
+++ b/src/components/list/evidenceProfileForm.vue
@@ -1053,7 +1053,9 @@ export default {
       }
       switch (type) {
         case 'methodological_limitations':
-          if (opt === '1') {
+          if (opt === '0') {
+            return 'No/very minor concerns regarding methodological limitations because'
+          } else if (opt === '1') {
             return 'Minor concerns regarding methodological limitations because'
           } else if (opt === '2') {
             return 'Moderate concerns regarding methodological limitations because'
@@ -1063,7 +1065,9 @@ export default {
             return ''
           }
         case 'coherence':
-          if (opt === '1') {
+          if (opt === '0') {
+            return 'No/very minor concerns regarding coherence because'
+          } else if (opt === '1') {
             return 'Minor concerns regarding coherence because'
           } else if (opt === '2') {
             return 'Moderate concerns regarding coherence because'
@@ -1073,7 +1077,9 @@ export default {
             return ''
           }
         case 'adequacy':
-          if (opt === '1') {
+          if (opt === '0') {
+            return 'No/very minor concerns regarding adequacy because'
+          } else if (opt === '1') {
             return 'Minor concerns regarding adequacy because'
           } else if (opt === '2') {
             return 'Moderate concerns regarding adequacy because'
@@ -1083,7 +1089,9 @@ export default {
             return ''
           }
         case 'relevance':
-          if (opt === '1') {
+          if (opt === '0') {
+            return 'No/very minor concerns regarding relevance because'
+          } else if (opt === '1') {
             return 'Minor concerns regarding relevance because'
           } else if (opt === '2') {
             return 'Moderate concerns regarding relevance because'

--- a/src/components/list/evidenceProfileForm.vue
+++ b/src/components/list/evidenceProfileForm.vue
@@ -956,22 +956,22 @@ export default {
     checkValidationText: function (type, prop) {
       switch (type) {
         case 'methodological-limitations':
-          if (prop.methodological_limitations.explanation === '') {
+          if (parseInt(prop.methodological_limitations.option) > 0 && prop.methodological_limitations.explanation === '') {
             return true
           }
           return false
         case 'coherence':
-          if (prop.coherence.explanation === '') {
+          if (parseInt(prop.coherence.option) > 0 && prop.coherence.explanation === '') {
             return true
           }
           return false
         case 'adequacy':
-          if (prop.adequacy.explanation === '') {
+          if (parseInt(prop.adequacy.option) > 0 && prop.adequacy.explanation === '') {
             return true
           }
           return false
         case 'relevance':
-          if (prop.relevance.explanation === '') {
+          if (parseInt(prop.relevance.option) > 0 && prop.relevance.explanation === '') {
             return true
           }
           return false

--- a/src/components/utils/commons.js
+++ b/src/components/utils/commons.js
@@ -2,9 +2,6 @@ export const displayExplanation = (type, option, explanation) => {
   if (type === '') {
     return ''
   }
-  // if (option === '0') {
-  //   return explanation
-  // }
   if (explanation === '') {
     return ''
   }
@@ -44,5 +41,37 @@ export const displayExplanation = (type, option, explanation) => {
       return `${options[option]} ${explanation}`
     default:
       return ''
+  }
+}
+
+function displaySelectedOption (option) {
+  const selectOptions = [
+    { value: 0, text: 'No/Very minor concerns' },
+    { value: 1, text: 'Minor concerns' },
+    { value: 2, text: 'Moderate concerns' },
+    { value: 3, text: 'Serious concerns' },
+    { value: null, text: 'Undefined' }
+  ]
+  if (option === null) {
+    return ''
+  } else if (option >= 0) {
+    return selectOptions[option].text
+  } else {
+    return ''
+  }
+}
+
+export const generateCerqualExplanation = (data) => {
+  if (data.cerqual.explanation === '') {
+    if (data.methodological_limitations.option &&
+    data.coherence.option &&
+    data.adequacy.option &&
+    data.relevance.option) {
+      return displaySelectedOption(data.methodological_limitations.option) + ' regarding methodological limitations, ' + displaySelectedOption(data.coherence.option) + ' regarding coherence, ' + displaySelectedOption(data.adequacy.option) + ' regarding adequacy, and ' + displaySelectedOption(data.relevance.option) + ' regarding relevance'
+    } else {
+      return ''
+    }
+  } else {
+    return data.cerqual.explanation
   }
 }

--- a/src/components/utils/commons.js
+++ b/src/components/utils/commons.js
@@ -2,9 +2,9 @@ export const displayExplanation = (type, option, explanation) => {
   if (type === '') {
     return ''
   }
-  if (option === '0') {
-    return explanation
-  }
+  // if (option === '0') {
+  //   return explanation
+  // }
   if (explanation === '') {
     return ''
   }
@@ -12,6 +12,7 @@ export const displayExplanation = (type, option, explanation) => {
   switch (type) {
     case 'methodological-limitations':
       options = {
+        '0': 'No/very minor concerns regarding methodological limitations because',
         '1': 'Minor concerns regarding methodological limitations because',
         '2': 'Moderate concerns regarding methodological limitations because',
         '3': 'Serious concerns regarding methodological limitations because'
@@ -19,6 +20,7 @@ export const displayExplanation = (type, option, explanation) => {
       return `${options[option]} ${explanation}`
     case 'coherence':
       options = {
+        '0': 'No/very minor concerns regarding coherence because',
         '1': 'Minor concerns regarding coherence because',
         '2': 'Moderate concerns regarding coherence because',
         '3': 'Serious concerns regarding coherence because'
@@ -26,6 +28,7 @@ export const displayExplanation = (type, option, explanation) => {
       return `${options[option]} ${explanation}`
     case 'adequacy':
       options = {
+        '0': 'No/very minor concerns regarding adequacy because',
         '1': 'Minor concerns regarding adequacy because',
         '2': 'Moderate concerns regarding adequacy because',
         '3': 'Serious concerns regarding adequacy because'
@@ -33,6 +36,7 @@ export const displayExplanation = (type, option, explanation) => {
       return `${options[option]} ${explanation}`
     case 'relevance':
       options = {
+        '0': 'No/very minor concerns regarding relevance because',
         '1': 'Minor concerns regarding relevance because',
         '2': 'Moderate concerns regarding relevance because',
         '3': 'Serious concerns regarding relevance because'


### PR DESCRIPTION
This pull request includes several changes to improve the display and validation of explanations in the evidence profile components. The most important changes include adding formatted text for explanations, updating validation logic, and introducing a new utility function to generate explanations.

Improvements to display and formatting:

* [`src/components/list/editListEvidenceProfile.vue`](diffhunk://#diff-67c662c5ff2188afd5dfe9abcafb48fd8e3a6a59ab5fe3e00430a039911afecdL144-R144): Added formatted text for explanations in multiple sections (`coherence`, `adequacy`, `relevance`, and `cerqual`). [[1]](diffhunk://#diff-67c662c5ff2188afd5dfe9abcafb48fd8e3a6a59ab5fe3e00430a039911afecdL144-R144) [[2]](diffhunk://#diff-67c662c5ff2188afd5dfe9abcafb48fd8e3a6a59ab5fe3e00430a039911afecdL199-R199) [[3]](diffhunk://#diff-67c662c5ff2188afd5dfe9abcafb48fd8e3a6a59ab5fe3e00430a039911afecdL254-R254) [[4]](diffhunk://#diff-67c662c5ff2188afd5dfe9abcafb48fd8e3a6a59ab5fe3e00430a039911afecdL308-R310)

Validation logic updates:

* [`src/components/list/editListEvidenceProfile.vue`](diffhunk://#diff-67c662c5ff2188afd5dfe9abcafb48fd8e3a6a59ab5fe3e00430a039911afecdL628-R645): Updated validation logic to use `parseInt` for numerical comparisons in the `checkValidationText` method.
* [`src/components/list/evidenceProfileForm.vue`](diffhunk://#diff-3a1d103d21f07e08faebbcd955b8f538d7d5b677f4cf153f6cc081ad95445d5aL959-R965): Updated validation logic to use `parseInt` for numerical comparisons in the `checkValidationText` method.

New utility functions:

* [`src/components/utils/commons.js`](diffhunk://#diff-7cf1332edc9b0c6b0379473163ac43143ddeb554a4345be6ab5835bfe5d3b4c4R46-R77): Added `generateCerqualExplanation` function to generate explanations based on selected options, and `displaySelectedOption` function to display text for selected options.

Event handling and method changes:

* [`src/components/list/evidenceProfileForm.vue`](diffhunk://#diff-3a1d103d21f07e08faebbcd955b8f538d7d5b677f4cf153f6cc081ad95445d5aL344-R344): Added `@change` event to `cerqual` radio group to call `commonGenerateCerqualExplanation` method.
* [`src/components/list/evidenceProfileForm.vue`](diffhunk://#diff-3a1d103d21f07e08faebbcd955b8f538d7d5b677f4cf153f6cc081ad95445d5aL895-R898): Removed computed property `cerqualExplanation` and added `commonGenerateCerqualExplanation` method to generate explanations.