### PR TITLE
Adjust column sizes in evidence profile form for improved layout on l…

### DIFF
--- a/src/components/list/evidenceProfileForm.vue
+++ b/src/components/list/evidenceProfileForm.vue
@@ -17,7 +17,7 @@
     </template>
     <b-container fluid>
       <b-row>
-        <b-col id="left-modal-content" cols="12" md="4">
+        <b-col id="left-modal-content" cols="12" xl="2" lg="3" md="4">
           <div class="float-right mb-5">
             <span id="span-txt" class="bg-secondary text-white font-weight-bold ml-5 py-1 px-2"
               @click="btnShowHideColumn(showPanel, selectedOptions.type)">&lsaquo;</span>
@@ -417,7 +417,7 @@
             </b-form-group>
           </div>
         </b-col>
-        <b-col id="right-modal-content" cols="12" md="8">
+        <b-col id="right-modal-content" cols="12" xl="10" lg="9" md="8">
           <div v-if="selectedOptions.type === 'methodological-limitations'">
             <b-tabs content-class="mt-3">
               <b-tab active>


### PR DESCRIPTION
This pull request includes changes to the layout of the `evidenceProfileForm.vue` component to improve the responsiveness and appearance of the modal content. The most important changes involve adjusting the column sizes for different screen sizes.

Changes to layout:

* [`src/components/list/evidenceProfileForm.vue`](diffhunk://#diff-3a1d103d21f07e08faebbcd955b8f538d7d5b677f4cf153f6cc081ad95445d5aL20-R20): Modified the column sizes for the left modal content to include `xl="2"` and `lg="3"` for better responsiveness.
* [`src/components/list/evidenceProfileForm.vue`](diffhunk://#diff-3a1d103d21f07e08faebbcd955b8f538d7d5b677f4cf153f6cc081ad95445d5aL420-R420): Modified the column sizes for the right modal content to include `xl="10"` and `lg="9"` for better responsiveness.…arger screens