### PR TITLE
Adjust column sizes in evidence profile form for better layout on smaller screens

### DIFF
--- a/src/components/organization/organizationForm.vue
+++ b/src/components/organization/organizationForm.vue
@@ -62,7 +62,7 @@
     </b-form-group>
     <b-form-group
       v-if="formData.published_status"
-      :label="$t('URL or DOI')"
+      :label="$t('URL or DOI (the DOI must begin with https:// as seen below)')"
       label-for="select-project-list-url-doi">
       <b-input
         :disabled="!canWrite"


### PR DESCRIPTION
Improve the layout of the evidence profile form by adjusting column sizes for better responsiveness, particularly on smaller screens.