### PR TITLE
Refactor condition to check for references and changeTab before updating stepStage

### DIFF
--- a/src/components/project/viewProject.vue
+++ b/src/components/project/viewProject.vue
@@ -1292,7 +1292,6 @@ export default {
         .then(async (response) => {
           this.references = await this.processGetReferencesRaw(response.data)
           this.refs = await this.processGetReferencesWithNames(response.data)
-
           if (changeTab) {
             if (this.references.length) {
               this.$nextTick(() => {
@@ -1308,7 +1307,7 @@ export default {
               })
             }
           }
-          if (this.references.length) {
+          if (this.references.length && changeTab) {
             this.stepStage = 1
           }
           this.loadReferences = false


### PR DESCRIPTION
This pull request includes a small change to the `src/components/project/viewProject.vue` file. The change ensures that the `stepStage` is set to 1 only if there are references and the `changeTab` condition is met.

* [`src/components/project/viewProject.vue`](diffhunk://#diff-84982011013ac6f3a1dca1453980dd0a9790002f98e9a8aff20e43afeea9c277L1311-R1310): Modified the condition to set `stepStage` to 1 only if both `this.references.length` and `changeTab` are true.