### PR TITLE
Feature/242 collaborators view only

### DIFF
--- a/src/components/editReviewFinding.vue
+++ b/src/components/editReviewFinding.vue
@@ -4,6 +4,7 @@
       <h4>Review Finding</h4>
       <p>{{ list.name }}</p>
       <b-button
+        v-if="permissions"
         variant="outline-primary"
         @click="ui.editMode=true">Edit</b-button>
     </template>
@@ -16,14 +17,16 @@
             max-rows="30"
             v-model="reviewContent"></b-form-textarea>
         </b-form>
-        <b-button
-          class="mt-2"
-          variant="outline-primary"
-          @click="updateReview">Update</b-button>
-        <b-button
-          class="mt-2"
-          variant="outline-secondary"
-          @click="ui.editMode=false">Cancel</b-button>
+        <template v-if="permissions">
+          <b-button
+            class="mt-2"
+            variant="outline-primary"
+            @click="updateReview">Update</b-button>
+          <b-button
+            class="mt-2"
+            variant="outline-secondary"
+            @click="ui.editMode=false">Cancel</b-button>
+        </template>
       </div>
     </template>
   </div>
@@ -36,7 +39,11 @@ export default {
   name: 'editReviewFinding',
   props: {
     list: Object,
-    finding: Object
+    finding: Object,
+    permissions: {
+      type: Object,
+      default: () => { return true }
+    }
   },
   data: function () {
     return {

--- a/src/components/list/editListEvidenceProfile.vue
+++ b/src/components/list/editListEvidenceProfile.vue
@@ -72,13 +72,14 @@
       </template>
       <template v-slot:cell(methodological-limit)="data">
         <div v-if="data.item.methodological_limitations.option !== null">
-          <template v-if="permission">
+          <template>
             <b-button
               block
               class="d-print-none mb-3"
               variant="outline-info"
               @click="editStageTwo(data.item, 'methodological-limitations')">
-              Edit
+              <template v-if="permission">Edit</template>
+              <template v-else>View</template>
               <font-awesome-icon
                 v-if="data.item.methodological_limitations.notes"
                 icon="comments"></font-awesome-icon>
@@ -127,13 +128,14 @@
       </template>
       <template v-slot:cell(coherence)="data">
         <div v-if="data.item.coherence.option !== null">
-          <template v-if="permission">
+          <template>
             <b-button
               block
               class="d-print-none mb-3"
               variant="outline-info"
               @click="editStageTwo(data.item, 'coherence')">
-              Edit
+              <template v-if="permission">Edit</template>
+              <template v-else>View</template>
               <font-awesome-icon
                 v-if="data.item.coherence.notes"
                 icon="comments"></font-awesome-icon>
@@ -182,13 +184,14 @@
       </template>
       <template v-slot:cell(adequacy)="data">
         <div v-if="data.item.adequacy.option !== null">
-          <template v-if="permission">
+          <template>
             <b-button
               block
               class="d-print-none mb-3"
               variant="outline-info"
               @click="editStageTwo(data.item, 'adequacy')">
-              Edit
+              <template v-if="permission">Edit</template>
+              <template v-else>View</template>
               <font-awesome-icon
                 v-if="data.item.adequacy.notes"
                 icon="comments"></font-awesome-icon>
@@ -237,13 +240,14 @@
       </template>
       <template v-slot:cell(relevance)="data">
         <div v-if="data.item.relevance.option !== null">
-          <template v-if="permission">
+          <template>
             <b-button
               block
               class="d-print-none mb-3"
               variant="outline-info"
               @click="editStageTwo(data.item, 'relevance')">
-              Edit
+              <template v-if="permission">Edit</template>
+              <template v-else>View</template>
               <font-awesome-icon
                 v-if="data.item.relevance.notes"
                 icon="comments"></font-awesome-icon>
@@ -292,13 +296,14 @@
       </template>
       <template v-slot:cell(cerqual)="data">
         <div v-if="data.item.methodological_limitations.option !== null && data.item.coherence.option !== null && data.item.adequacy.option !== null && data.item.relevance.option !== null && data.item.cerqual.option !== null">
-          <template v-if="permission">
+          <template>
             <b-button
               block
               class="d-print-none mb-3"
               variant="outline-info"
               @click="editStageTwo(data.item, 'cerqual')">
-              Edit
+              <template v-if="permission">Edit</template>
+              <template v-else>View</template>
               <font-awesome-icon
                 v-if="data.item.cerqual.notes"
                 icon="comments"></font-awesome-icon>
@@ -329,13 +334,14 @@
         </div>
       </template>
       <template v-slot:cell(references)="data">
-        <template v-if="permission">
+        <template>
           <b-button
             block
             class="d-print-none mb-3"
             variant="outline-info"
             @click="openModalReferences">
-            View or Edit references
+            <template v-if="permission">Edit references</template>
+            <template v-else>View references</template>
           </b-button>
         </template>
         There are <b>{{ data.item.references.length }}</b> references.
@@ -432,7 +438,8 @@
       title="References"
       size="xl"
       scrollable
-      @ok="saveReferencesList">
+      @ok="saveReferencesList"
+      :ok-disabled="!permission">
       <b-alert
         v-if="list.cerqual.option"
         show
@@ -449,7 +456,8 @@
             :id="`checkbox-${data.index}`"
             v-model="list.references"
             :name="`checkbox-${data.index}`"
-            :value="data.item.id">
+            :value="data.item.id"
+            :disabled="!permission">
           </b-form-checkbox>
         </template>
       </b-table>
@@ -471,6 +479,7 @@
       :project="project"
       :evidenceProfile="evidenceProfile"
       :selectOptions="selectOptions"
+      :permissions="permission"
       @update-list-data="getList"
       @busyEvidenceProfileTable="busyEvidenceProfileTable"
       @callGetStageOneData="callGetStageOneData"

--- a/src/components/list/evidenceProfileForm.vue
+++ b/src/components/list/evidenceProfileForm.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
   <b-modal id="modal-evidence-profile-form" ref="modal-evidence-profile-form" scrollable
+    :ok-disabled="!permissions"
     @ok="saveStageOneAndTwo(selectedOptions.type, $event)" ok-title="Save" ok-variant="outline-success"
     cancel-variant="outline-secondary">
     <template v-slot:modal-title>
@@ -43,7 +44,7 @@
               }">here</b-link>)
             </p>
             <b-form-radio-group v-model="selectedOptions.methodological_limitations.option"
-              name="methodological-limitations" stacked>
+              name="methodological-limitations" stacked :disabled="!permissions">
               <b-form-radio value="0">
                 No/Very minor concerns
                 <small v-b-tooltip.hover
@@ -65,7 +66,7 @@
                   title="Serious concerns regarding methodological limitations that are very likely to reduce confidence in the review finding">*</small>
               </b-form-radio>
             </b-form-radio-group>
-            <p class="mt-2 font-weight-light text-danger" style="cursor: pointer">
+            <p v-if="permissions" class="mt-2 font-weight-light text-danger" style="cursor: pointer">
               <a @click="selectedOptions.methodological_limitations.option = null; selectedOptions.methodological_limitations.explanation = ''; selectedOptions.methodological_limitations.example = '';"
                 v-if="selectedOptions.methodological_limitations.option !== null">
                 <font-awesome-icon icon="trash"></font-awesome-icon>
@@ -91,7 +92,7 @@
               </template>
               <b-form-textarea id="input-ml-explanation"
                 v-model="selectedOptions.methodological_limitations.explanation" rows="6"
-                max-rows="100"></b-form-textarea>
+                max-rows="100" :disabled="!permissions"></b-form-textarea>
             </b-form-group>
             <b-form-group class="mt-2 font-weight-light" label-for="input-ml-notes"
               description="Optional space for reviewers to leave notes for each other while working on GRADE-CERQual assessments">
@@ -99,7 +100,7 @@
                 <videoHelp txt="Notes" tag="none" urlId="462180668"></videoHelp>
               </template>
               <b-form-textarea id="input-ml-notes" v-model="selectedOptions.methodological_limitations.notes" rows="6"
-                max-rows="100"></b-form-textarea>
+                max-rows="100" :disabled="!permissions"></b-form-textarea>
             </b-form-group>
           </div>
 
@@ -130,7 +131,7 @@
               studies, but is about the fit between the extracted data and the
               review finding as you have written it.
             </p>
-            <b-form-radio-group v-model="selectedOptions.coherence.option" name="coherence" stacked>
+            <b-form-radio-group v-model="selectedOptions.coherence.option" name="coherence" stacked :disabled="!permissions">
               <b-form-radio value="0">
                 No/Very minor concerns
                 <small v-b-tooltip.hover
@@ -152,7 +153,7 @@
                   title="Serious concerns regarding coherence that are very likely to reduce confidence in the review finding">*</small>
               </b-form-radio>
             </b-form-radio-group>
-            <p class="mt-2 font-weight-light text-danger" style="cursor: pointer">
+            <p v-if="permissions" class="mt-2 font-weight-light text-danger" style="cursor: pointer">
               <a @click="selectedOptions.coherence.option = null; selectedOptions.coherence.explanation = '';" v-if="selectedOptions.coherence.option !== null">
                 <font-awesome-icon icon="trash"></font-awesome-icon>
                 clear my selection
@@ -174,7 +175,7 @@
                   target="_blank">here</a>
                 to see an example.
               </template>
-              <b-form-textarea id="input-coherence-explanation" v-model="selectedOptions.coherence.explanation" :placeholder="selectedOptions.coherence.option === '0' ? '' : ''" rows="6" max-rows="100"></b-form-textarea>
+              <b-form-textarea id="input-coherence-explanation" v-model="selectedOptions.coherence.explanation" :placeholder="selectedOptions.coherence.option === '0' ? '' : ''" rows="6" max-rows="100" :disabled="!permissions"></b-form-textarea>
             </b-form-group>
             <b-form-group class="mt-2 font-weight-light" label-for="input-ml-notes"
               description="Optional space for reviewers to leave notes for each other while working on GRADE-CERQual assessments">
@@ -182,7 +183,7 @@
                 <videoHelp txt="Notes" tag="none" urlId="462180668"></videoHelp>
               </template>
               <b-form-textarea id="input-ml-notes" v-model="selectedOptions.coherence.notes" rows="6"
-                max-rows="100"></b-form-textarea>
+                max-rows="100" :disabled="!permissions"></b-form-textarea>
             </b-form-group>
             <!-- adequacy -->
           </div>
@@ -202,7 +203,7 @@
                 query: { tab: 'Guidance-on-applying-GRADE-CERQual' }
               }">here</b-link>)
             </p>
-            <b-form-radio-group v-model="selectedOptions.adequacy.option" name="adequacy" stacked>
+            <b-form-radio-group v-model="selectedOptions.adequacy.option" name="adequacy" stacked :disabled="!permissions">
               <b-form-radio value="0">
                 No/Very minor concerns
                 <small v-b-tooltip.hover
@@ -224,7 +225,7 @@
                   title="Serious concerns regarding adequacy that are very likely to reduce confidence in the review finding">*</small>
               </b-form-radio>
             </b-form-radio-group>
-            <p class="mt-2 font-weight-light text-danger" style="cursor: pointer">
+            <p v-if="permissions" class="mt-2 font-weight-light text-danger" style="cursor: pointer">
               <a @click="selectedOptions.adequacy.option = null; selectedOptions.adequacy.explanation = ''; " v-if="selectedOptions.adequacy.option !== null">
                 <font-awesome-icon icon="trash"></font-awesome-icon>
                 clear my selection
@@ -243,7 +244,7 @@
                   target="_blank">here</a>
                 to see an example.
               </template>
-              <b-form-textarea id="input-adequacy-explanation" v-model="selectedOptions.adequacy.explanation" :placeholder="selectedOptions.adequacy.option === '0' ? '' : ''" rows="6" max-rows="100"></b-form-textarea>
+              <b-form-textarea id="input-adequacy-explanation" v-model="selectedOptions.adequacy.explanation" :placeholder="selectedOptions.adequacy.option === '0' ? '' : ''" rows="6" max-rows="100" :disabled="!permissions"></b-form-textarea>
             </b-form-group>
             <b-form-group class="mt-2 font-weight-light" label-for="input-ml-notes"
               description="Optional space for reviewers to leave notes for each other while working on GRADE-CERQual assessments">
@@ -251,7 +252,7 @@
                 <videoHelp txt="Notes" tag="none" urlId="462180668"></videoHelp>
               </template>
               <b-form-textarea id="input-ml-notes" v-model="selectedOptions.adequacy.notes" rows="6"
-                max-rows="100"></b-form-textarea>
+                max-rows="100" :disabled="!permissions"></b-form-textarea>
             </b-form-group>
             <!-- relevance -->
           </div>
@@ -275,7 +276,7 @@
                 query: { tab: 'Guidance-on-applying-GRADE-CERQual' }
               }">here</b-link>)
             </p>
-            <b-form-radio-group v-model="selectedOptions.relevance.option" name="relevance" stacked>
+            <b-form-radio-group v-model="selectedOptions.relevance.option" name="relevance" stacked :disabled="!permissions">
               <b-form-radio value="0">
                 No/Very minor concerns
                 <small v-b-tooltip.hover
@@ -297,7 +298,7 @@
                   title="Serious concerns regarding relevance that are very likely to reduce confidence in the review finding">*</small>
               </b-form-radio>
             </b-form-radio-group>
-            <p class="mt-2 font-weight-light text-danger" style="cursor: pointer">
+            <p v-if="permissions" class="mt-2 font-weight-light text-danger" style="cursor: pointer">
               <a @click="selectedOptions.relevance.option = null; selectedOptions.relevance.explanation = '';" v-if="selectedOptions.relevance.option !== null">
                 <font-awesome-icon icon="trash"></font-awesome-icon>
                 clear my selection
@@ -310,7 +311,7 @@
                   {{ showMessage(selectedOptions.relevance.option, 'relevance') }}
                 </p>
               </template>
-              <b-form-textarea id="input-relevance-explanation" v-model="selectedOptions.relevance.explanation" :placeholder="selectedOptions.relevance.option === '0' ? '' : ''" rows="6" max-rows="100"></b-form-textarea>
+              <b-form-textarea id="input-relevance-explanation" v-model="selectedOptions.relevance.explanation" :placeholder="selectedOptions.relevance.option === '0' ? '' : ''" rows="6" max-rows="100" :disabled="!permissions"></b-form-textarea>
             </b-form-group>
             <b-form-group class="mt-2 font-weight-light" label-for="input-ml-notes">
               <template slot="label">
@@ -324,7 +325,7 @@
                 to see an example.
               </template>
               <b-form-textarea id="input-ml-notes" v-model="selectedOptions.relevance.notes" rows="6"
-                max-rows="100"></b-form-textarea>
+                max-rows="100" :disabled="!permissions"></b-form-textarea>
             </b-form-group>
             <!-- CERQual assessment -->
           </div>
@@ -341,7 +342,7 @@
               for practical guidance on making an overall assessment of confidence
               for a review finding.
             </p>
-            <b-form-radio-group v-model="selectedOptions.cerqual.option" @change="commonGenerateCerqualExplanation()" name="cerqual" stacked>
+            <b-form-radio-group v-model="selectedOptions.cerqual.option" @change="commonGenerateCerqualExplanation()" name="cerqual" stacked :disabled="!permissions">
               <b-form-radio value="0">
                 High confidence
                 <small v-b-tooltip.hover
@@ -363,7 +364,7 @@
                   title="It is not clear whether the review finding is a reasonable representation of the phenomenon of interest">*</small>
               </b-form-radio>
             </b-form-radio-group>
-            <p class="mt-2 font-weight-light text-danger" style="cursor: pointer">
+            <p v-if="permissions" class="mt-2 font-weight-light text-danger" style="cursor: pointer">
               <a @click="selectedOptions.cerqual.option = null; selectedOptions.cerqual.explanation = '';" v-if="selectedOptions.cerqual.option !== null">
                 <font-awesome-icon icon="trash"></font-awesome-icon>
                 clear my selection
@@ -405,7 +406,7 @@
                 </div>
               </template>
               <b-form-textarea id="input-cerqual" v-model="selectedOptions.cerqual.explanation"
-                placeholder="Enter an explanation" rows="6" max-rows="100"></b-form-textarea>
+                placeholder="Enter an explanation" rows="6" max-rows="100" :disabled="!permissions"></b-form-textarea>
             </b-form-group>
             <b-form-group class="mt-2 font-weight-light" label-for="input-ml-notes"
               description="Optional space for reviewers to leave notes for each other while working on GRADE-CERQual assessments">
@@ -413,7 +414,7 @@
                 <videoHelp txt="Notes" tag="none" urlId="462180668"></videoHelp>
               </template>
               <b-form-textarea id="input-ml-notes" v-model="selectedOptions.cerqual.notes" rows="6"
-                max-rows="100"></b-form-textarea>
+                max-rows="100" :disabled="!permissions"></b-form-textarea>
             </b-form-group>
           </div>
         </b-col>
@@ -448,7 +449,7 @@
                 </b-table>
               </b-tab>
               <b-tab title="Review Finding">
-                <edit-review-finding @update-list-data="getList(true)" :list="list" :finding="findings">
+                <edit-review-finding @update-list-data="getList(true)" :list="list" :finding="findings" :permissions="permissions">
                 </edit-review-finding>
               </b-tab>
               <b-tab>
@@ -503,7 +504,7 @@
                       </b-button>
                     </template>
                     <template v-else>
-                      <b-button variant="outline-success" @click="editExtractedDataInPlace(data.index)">
+                      <b-button v-if="permissions" variant="outline-success" @click="editExtractedDataInPlace(data.index)">
                         <font-awesome-icon icon="edit" :title="$t('Edit')" />
                       </b-button>
                     </template>
@@ -514,7 +515,7 @@
           </div>
 
           <div v-if="selectedOptions.type === 'coherence'">
-            <edit-review-finding @update-list-data="getList(true)" :list="list" :finding="findings">
+            <edit-review-finding @update-list-data="getList(true)" :list="list" :finding="findings" :permissions="permissions">
             </edit-review-finding>
             <h4>Extracted Data</h4>
             <p v-if="ui.adequacy.extracted_data.display_warning" class="text-danger">
@@ -555,7 +556,7 @@
                   </b-button>
                 </template>
                 <template v-else>
-                  <b-button variant="outline-success" @click="editExtractedDataInPlace(data.index)">
+                  <b-button v-if="permissions" variant="outline-success" @click="editExtractedDataInPlace(data.index)">
                     <font-awesome-icon icon="edit" :title="$t('Edit')" />
                   </b-button>
                 </template>
@@ -614,7 +615,7 @@
                       </b-button>
                     </template>
                     <template v-else>
-                      <b-button variant="outline-success" @click="editExtractedDataInPlace(data.index)">
+                      <b-button v-if="permissions" variant="outline-success" @click="editExtractedDataInPlace(data.index)">
                         <font-awesome-icon icon="edit" :title="$t('Edit')" />
                       </b-button>
                     </template>
@@ -649,7 +650,7 @@
                 </b-table>
               </b-tab>
               <b-tab title="Review Finding">
-                <edit-review-finding @update-list-data="getList(true)" :list="list" :finding="findings">
+                <edit-review-finding @update-list-data="getList(true)" :list="list" :finding="findings" :permissions="permissions">
                 </edit-review-finding>
               </b-tab>
             </b-tabs>
@@ -741,7 +742,7 @@
                 </b-table>
               </b-tab>
               <b-tab title="Review Finding">
-                <edit-review-finding @update-list-data="getList(true)" :list="list" :finding="findings">
+                <edit-review-finding @update-list-data="getList(true)" :list="list" :finding="findings" :permissions="permissions">
                 </edit-review-finding>
               </b-tab>
             </b-tabs>
@@ -792,7 +793,7 @@
                 </p>
               </b-tab>
               <b-tab title="Review finding">
-                <edit-review-finding @update-list-data="getList(true)" :list="list" :finding="findings">
+                <edit-review-finding @update-list-data="getList(true)" :list="list" :finding="findings" :permissions="permissions">
                 </edit-review-finding>
               </b-tab>
             </b-tabs>
@@ -852,7 +853,8 @@ export default {
     charsOfStudies: Object,
     project: Object,
     evidenceProfile: Array,
-    selectOptions: Array
+    selectOptions: Array,
+    permissions: Boolean
   },
   data () {
     return {

--- a/src/components/project/UploadReferences.vue
+++ b/src/components/project/UploadReferences.vue
@@ -224,7 +224,7 @@
               </b-card>
             </template>
           </b-table>
-          <div class="mt-2">
+          <div v-if="checkPermissions" class="mt-2">
             <b-button
             @click="confirmRemoveAllReferences($event)"
               >Delete all references</b-button>

--- a/src/components/project/crudTables.vue
+++ b/src/components/project/crudTables.vue
@@ -66,10 +66,11 @@
           </template>
           <template
             v-slot:cell(actions)="data"
-            v-if="dataTable.fields.length > 2">
+            v-if="dataTable.fields.length > 2 && checkPermissions">
             <b-row>
               <b-col>
                 <b-button
+                  v-if="checkPermissions"
                   block
                   variant="outline-success"
                   @click="addContentDataTable((dataTableSettings.currentPage > 1) ? (dataTableSettings.perPage * (dataTableSettings.currentPage - 1)) + data.index : data.index)">
@@ -79,6 +80,7 @@
               </b-col>
               <b-col class="pt-2">
                 <b-button
+                  v-if="checkPermissions"
                   block
                   variant="outline-danger"
                   @click="openModalRemoveContentDataTable(data.item.ref_id)">
@@ -508,7 +510,10 @@ export default {
             const dataTable = JSON.parse(JSON.stringify(response.data[0]))
             this.dataTable = dataTable
             if (Object.prototype.hasOwnProperty.call(this.dataTable, 'fields')) {
-              this.dataTable.fieldsObj = [{'key': 'actions', 'label': '', stickyColumn: true}, { 'key': 'authors', 'label': 'Author(s), Year' }]
+              this.dataTable.fieldsObj = [{ 'key': 'authors', 'label': 'Author(s), Year' }]
+              if (this.checkPermissions) {
+                this.dataTable.fieldsObj = [{'key': 'actions', 'label': '', stickyColumn: true}, { 'key': 'authors', 'label': 'Author(s), Year' }]
+              }
 
               const fields = JSON.parse(JSON.stringify(this.dataTable.fields))
               const items = JSON.parse(JSON.stringify(this.dataTable.items))

--- a/src/components/project/viewProject.vue
+++ b/src/components/project/viewProject.vue
@@ -372,7 +372,7 @@
           </b-col>
           <b-col cols="12" class="toDoc">
             <template
-              v-if="mode==='edit' && checkPermissions()">
+              v-if="mode==='edit'">
               <b-table
                 :selectable="(mode==='view')?true:false"
                 select-mode="multi"
@@ -451,7 +451,7 @@
                 </template>
                 <template v-slot:cell(name)="data">
                   <a :id="`a-${data.item.id}`"></a>
-                  <span v-if="mode === 'edit'">
+                  <template v-if="mode === 'edit' && checkPermissions()">
                     <b-row
                       class="mb-3">
                       <b-col
@@ -483,34 +483,37 @@
                     </b-row>
                     <b-link class="table-edit-list" v-if="data.item.references.length" :to="{name: 'editList', params: {id: data.item.id}}">{{ data.item.name }}</b-link>
                     <span v-if="data.item.references.length === 0">{{ data.item.name }}</span>
-                  </span>
-                  <span v-else>
-                    {{ data.item.name }}
-                  </span>
-                </template>
-                <template v-slot:cell(category_name)="data">
-                  <template v-if="data.item.category !== null">
-                    <b-button
-                      block
-                      variant="outline-info"
-                      @click="editModalFindingName(data)">Edit group</b-button>
-                    {{ data.item.category_name }}
-                    <span
-                      v-if="data.item.category_extra_info !== ''"
-                      v-b-tooltip.hover
-                      :title="data.item.category_extra_info">*</span>
                   </template>
                   <template v-else>
-                    <b-button
-                      v-if="mode==='edit' && data.item.references.length"
-                      variant="info"
-                      block
-                      @click="editModalFindingName(data)">Assign group</b-button>
+                    <b-link class="table-edit-list" v-if="data.item.references.length" :to="{name: 'editList', params: {id: data.item.id}}">{{ data.item.name }}</b-link>
+                    <span v-if="data.item.references.length === 0">{{ data.item.name }}</span>
+                  </template>
+                </template>
+                <template v-slot:cell(category_name)="data">
+                  <template v-if="checkPermissions()">
+                    <template v-if="data.item.category !== null">
+                      <b-button
+                        block
+                        variant="outline-info"
+                        @click="editModalFindingName(data)">Edit group</b-button>
+                      {{ data.item.category_name }}
+                      <span
+                        v-if="data.item.category_extra_info !== ''"
+                        v-b-tooltip.hover
+                        :title="data.item.category_extra_info">*</span>
+                    </template>
+                    <template v-else>
+                      <b-button
+                        v-if="mode==='edit' && data.item.references.length"
+                        variant="info"
+                        block
+                        @click="editModalFindingName(data)">Assign group</b-button>
+                    </template>
                   </template>
                 </template>
                 <template v-slot:cell(cerqual_option)="data">
                   <b-button
-                    v-if="mode==='edit' && data.item.references.length"
+                    v-if="mode==='edit' && data.item.references.length && checkPermissions()"
                     class="d-print-none mb-3"
                     :disabled="(data.item.references.length) ? false : true"
                     block
@@ -527,7 +530,7 @@
                 </template>
                 <template v-slot:cell(cerqual_explanation)="data">
                   <b-button
-                    v-if="mode==='edit' && data.item.references.length"
+                    v-if="mode==='edit' && data.item.references.length && checkPermissions()"
                     class="d-print-none mb-3"
                     :disabled="(data.item.references.length) ? false : true"
                     block
@@ -548,6 +551,7 @@
                   </template>
                   <template v-else>
                     <b-button
+                      v-if="checkPermissions()"
                       block
                       class="mb-3 d-print-none"
                       :variant="(data.item.references.length) ? 'outline-info' : 'info'"


### PR DESCRIPTION
This pull request includes changes to the `src/components/editReviewFinding.vue`, `src/components/list/editListEvidenceProfile.vue`, and `src/components/list/evidenceProfileForm.vue` files to handle user permissions more effectively. The updates ensure that certain actions and inputs are only enabled or visible when the user has the appropriate permissions.

### User Permissions Handling:

* [`src/components/editReviewFinding.vue`](diffhunk://#diff-af97c703d9ac970ae940043357e8897d99d6c5e1ef13f6a9fecd34af5cbfb6e3R7): Added a `permissions` prop and conditional rendering to buttons and templates based on user permissions. [[1]](diffhunk://#diff-af97c703d9ac970ae940043357e8897d99d6c5e1ef13f6a9fecd34af5cbfb6e3R7) [[2]](diffhunk://#diff-af97c703d9ac970ae940043357e8897d99d6c5e1ef13f6a9fecd34af5cbfb6e3R20) [[3]](diffhunk://#diff-af97c703d9ac970ae940043357e8897d99d6c5e1ef13f6a9fecd34af5cbfb6e3R29) [[4]](diffhunk://#diff-af97c703d9ac970ae940043357e8897d99d6c5e1ef13f6a9fecd34af5cbfb6e3L39-R46)

* [`src/components/list/editListEvidenceProfile.vue`](diffhunk://#diff-67c662c5ff2188afd5dfe9abcafb48fd8e3a6a59ab5fe3e00430a039911afecdL75-R82): Updated multiple button templates and form elements to conditionally display "Edit" or "View" based on user permissions. Also added the `permissions` prop to disable certain actions when permissions are not granted. [[1]](diffhunk://#diff-67c662c5ff2188afd5dfe9abcafb48fd8e3a6a59ab5fe3e00430a039911afecdL75-R82) [[2]](diffhunk://#diff-67c662c5ff2188afd5dfe9abcafb48fd8e3a6a59ab5fe3e00430a039911afecdL130-R138) [[3]](diffhunk://#diff-67c662c5ff2188afd5dfe9abcafb48fd8e3a6a59ab5fe3e00430a039911afecdL185-R194) [[4]](diffhunk://#diff-67c662c5ff2188afd5dfe9abcafb48fd8e3a6a59ab5fe3e00430a039911afecdL240-R250) [[5]](diffhunk://#diff-67c662c5ff2188afd5dfe9abcafb48fd8e3a6a59ab5fe3e00430a039911afecdL295-R306) [[6]](diffhunk://#diff-67c662c5ff2188afd5dfe9abcafb48fd8e3a6a59ab5fe3e00430a039911afecdL332-R344) [[7]](diffhunk://#diff-67c662c5ff2188afd5dfe9abcafb48fd8e3a6a59ab5fe3e00430a039911afecdL435-R442) [[8]](diffhunk://#diff-67c662c5ff2188afd5dfe9abcafb48fd8e3a6a59ab5fe3e00430a039911afecdL452-R460) [[9]](diffhunk://#diff-67c662c5ff2188afd5dfe9abcafb48fd8e3a6a59ab5fe3e00430a039911afecdR482)

* [`src/components/list/evidenceProfileForm.vue`](diffhunk://#diff-3a1d103d21f07e08faebbcd955b8f538d7d5b677f4cf153f6cc081ad95445d5aR4): Added the `permissions` prop and updated form elements and buttons to be disabled when permissions are not granted. [[1]](diffhunk://#diff-3a1d103d21f07e08faebbcd955b8f538d7d5b677f4cf153f6cc081ad95445d5aR4) [[2]](diffhunk://#diff-3a1d103d21f07e08faebbcd955b8f538d7d5b677f4cf153f6cc081ad95445d5aL46-R47) [[3]](diffhunk://#diff-3a1d103d21f07e08faebbcd955b8f538d7d5b677f4cf153f6cc081ad95445d5aL68-R69) [[4]](diffhunk://#diff-3a1d103d21f07e08faebbcd955b8f538d7d5b677f4cf153f6cc081ad95445d5aL94-R103) [[5]](diffhunk://#diff-3a1d103d21f07e08faebbcd955b8f538d7d5b677f4cf153f6cc081ad95445d5aL133-R134) [[6]](diffhunk://#diff-3a1d103d21f07e08faebbcd955b8f538d7d5b677f4cf153f6cc081ad95445d5aL155-R156) [[7]](diffhunk://#diff-3a1d103d21f07e08faebbcd955b8f538d7d5b677f4cf153f6cc081ad95445d5aL177-R186) [[8]](diffhunk://#diff-3a1d103d21f07e08faebbcd955b8f538d7d5b677f4cf153f6cc081ad95445d5aL205-R206) [[9]](diffhunk://#diff-3a1d103d21f07e08faebbcd955b8f538d7d5b677f4cf153f6cc081ad95445d5aL227-R228) [[10]](diffhunk://#diff-3a1d103d21f07e08faebbcd955b8f538d7d5b677f4cf153f6cc081ad95445d5aL246-R255) [[11]](diffhunk://#diff-3a1d103d21f07e08faebbcd955b8f538d7d5b677f4cf153f6cc081ad95445d5aL278-R279) [[12]](diffhunk://#diff-3a1d103d21f07e08faebbcd955b8f538d7d5b677f4cf153f6cc081ad95445d5aL300-R301) [[13]](diffhunk://#diff-3a1d103d21f07e08faebbcd955b8f538d7d5b677f4cf153f6cc081ad95445d5aL313-R314) [[14]](diffhunk://#diff-3a1d103d21f07e08faebbcd955b8f538d7d5b677f4cf153f6cc081ad95445d5aL327-R328)