### PR TITLE
Add warning modal for additional assessment option changes in evidence profile

### DIFF
--- a/src/components/list/evidenceProfileForm.vue
+++ b/src/components/list/evidenceProfileForm.vue
@@ -914,7 +914,22 @@ export default {
       this.selectedOptions = JSON.parse(JSON.stringify(this.modalData))
     },
     'selectedOptions.methodological_limitations.option': function (val) {
-      if (this.modalData.methodological_limitations.option !== val) {
+      if (this.modalData.methodological_limitations.option !== val && this.modalData.cerqual.option !== null) {
+        this.$refs['modal-warning-changed-option'].show()
+      }
+    },
+    'selectedOptions.coherence.option': function (val) {
+      if (this.modalData.coherence.option !== val && this.modalData.cerqual.option !== null) {
+        this.$refs['modal-warning-changed-option'].show()
+      }
+    },
+    'selectedOptions.adequacy.option': function (val) {
+      if (this.modalData.adequacy.option !== val && this.modalData.cerqual.option !== null) {
+        this.$refs['modal-warning-changed-option'].show()
+      }
+    },
+    'selectedOptions.relevance.option': function (val) {
+      if (this.modalData.relevance.option !== val && this.modalData.cerqual.option !== null) {
         this.$refs['modal-warning-changed-option'].show()
       }
     }


### PR DESCRIPTION
This pull request includes changes to the `src/components/list/evidenceProfileForm.vue` file to improve the handling of option changes in the evidence profile form. The most important changes include adding conditions to show a warning modal when specific options are changed.

Changes to handling option changes:

* Added condition to show a warning modal when `methodological_limitations.option` is changed and `cerqual.option` is not null.
* Added condition to show a warning modal when `coherence.option` is changed and `cerqual.option` is not null.
* Added condition to show a warning modal when `adequacy.option` is changed and `cerqual.option` is not null.
* Added condition to show a warning modal when `relevance.option` is changed and `cerqual.option` is not null.