### PR TITLE
Remove clearing of explanation text for selected options

### DIFF
--- a/src/components/list/evidenceProfileForm.vue
+++ b/src/components/list/evidenceProfileForm.vue
@@ -1022,7 +1022,6 @@ export default {
         option = 'methodological_limitations'
       }
       if (status) {
-        this.selectedOptions[option].explanation = ''
         this.selectedOptions.cerqual.option = null
         this.selectedOptions.cerqual.explanation = ''
         this.$refs['modal-warning-changed-option'].hide()


### PR DESCRIPTION
This pull request includes a small change to the `src/components/list/evidenceProfileForm.vue` file. The change removes the line that sets the `explanation` property of the `selectedOptions` object to an empty string when a status is present.

Change in `src/components/list/evidenceProfileForm.vue`:

* Removed the line that set `this.selectedOptions[option].explanation` to an empty string when a status is present