### PR TITLE
Update scroll behavior

### DIFF
--- a/src/components/list/editList.vue
+++ b/src/components/list/editList.vue
@@ -506,7 +506,9 @@ export default {
           this.getCharsOfStudies()
           this.getMethAssessments()
           this.evidence_profile_table_settings.isBusy = false
-          window.scrollTo({ top: 0, behavior: 'smooth' })
+          const elementScroll = document.getElementsByName('evidence-profile')[0]
+
+          window.scrollTo({ top: elementScroll.offsetParent.offsetTop, behavior: 'smooth' })
         })
         .catch((error) => {
           this.printErrors(error)


### PR DESCRIPTION
This pull request includes a small but important change to the `src/components/list/editList.vue` file. The change modifies the scroll behavior after certain asynchronous operations are completed.

* [`src/components/list/editList.vue`](diffhunk://#diff-448c1b3dd3e79491908794803966e4dc38025c8d84ce439f6a3ac962da8aa992L509-R511): Updated the scroll behavior to scroll to the top of the `evidence-profile` element instead of the top of the window.