### PR TITLE
Initialize sharedToken property and ensure it defaults to an empty

### DIFF
--- a/src/components/organization/viewOrganization.vue
+++ b/src/components/organization/viewOrganization.vue
@@ -621,6 +621,12 @@ export default {
         project.can_read.includes(this.$store.state.user.id) ||
         project.can_write.includes(this.$store.state.user.id)
       ) {
+        if (!Object.prototype.hasOwnProperty.call(project, 'sharedToken')) {
+          project.sharedToken = ''
+        }
+        if (project.sharedToken === null || project.sharedToken === undefined) {
+          project.sharedToken = ''
+        }
         if (!Object.prototype.hasOwnProperty.call(project, 'sharedTokenOnOff')) {
           if (Object.prototype.hasOwnProperty.call(project, 'sharedToken') && project.sharedToken.length) {
             project.sharedTokenOnOff = true


### PR DESCRIPTION
This pull request introduces a small update to handle missing or null `sharedToken` properties in the `viewOrganization.vue` component. The change ensures that `project.sharedToken` is always initialized to an empty string if it is not present or is null/undefined.

* [`src/components/organization/viewOrganization.vue`](diffhunk://#diff-6b9926ade4ebdb9384199dbbba07a0a78b3b7a9e7bb34c029023e380cde43663R624-R629): Added checks to initialize `project.sharedToken` to an empty string if it is missing or has a null/undefined value.